### PR TITLE
KLS-328 - Patch directory-healthcheck setuptools to version 66.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 3.0.2
+[Full Changelog](https://github.com/uktrade/directory-healthcheck/pull/20/files) (2023-01-20)
+
+### Enhancement
+- KLS-328 - Patch directory-healthcheck setuptools to version 66.1.0
 
 ## 3.0.1
 [Full Changelog](https://github.com/uktrade/directory-healthcheck/pull/19/files) (2022-09-20)

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ setup(
             "twine>=1.11.0,<2.0.0",
             "wheel>=0.31.0,<1.0.0",
             "raven==5.19.0",
-            "setuptools>=66.1.0,<66.1.0",
+            "setuptools>=59.6.0,<66.1.0",
             "directory-sso-api-client",
             "directory-api-client",
             "directory-forms-api-client",

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import find_packages, setup
 
 setup(
     name="directory_healthcheck",
-    version="3.0.1",
+    version="3.0.2",
     url="https://github.com/uktrade/directory-healthcheck",
     license="MIT",
     author="Department for International Trade",
@@ -28,7 +28,7 @@ setup(
             "twine>=1.11.0,<2.0.0",
             "wheel>=0.31.0,<1.0.0",
             "raven==5.19.0",
-            "setuptools>=38.6.0,<39.0.0",
+            "setuptools>=66.1.0,<66.1.0",
             "directory-sso-api-client",
             "directory-api-client",
             "directory-forms-api-client",


### PR DESCRIPTION
To do (delete all that do not apply):

 - [ ] Change has a jira ticket that has the correct status.
 - [ ] Changelog entry added.
 - [ ] (if there are vulnerable requirements) Upgraded any vulnerable dependencies.
 - [ ] (if updating requirements) Requirements have been compiled.
 - [ ] (if adding env vars) Added any new environment variable to vault.
 - [ ] (if adding feature flags) Cleaned up old flags
