### PR TITLE
bump django to 4.1.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 3.2.0
+[Full Changelog]() (2023-07-20)
+### Enhancement
+- KLS-911 - Upgrade Django to 4.1.10
+
 ## 3.0.4
 [Full Changelog](https://github.com/uktrade/directory-healthcheck/pull/23/files) (2023-04-06)
 ### Enhancement

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 3.2.0
+## 3.1.2
 [Full Changelog](https://github.com/uktrade/directory-healthcheck/pull/26/files) (2023-07-20)
 ### Enhancement
 - KLS-911 - Upgrade Django to 4.1.10

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 ## 3.2.0
-[Full Changelog]() (2023-07-20)
+[Full Changelog](https://github.com/uktrade/directory-healthcheck/pull/26/files) (2023-07-20)
 ### Enhancement
 - KLS-911 - Upgrade Django to 4.1.10
 

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import find_packages, setup
 
 setup(
     name="directory_healthcheck",
-    version="3.2.0",
+    version="3.1.2",
     url="https://github.com/uktrade/directory-healthcheck",
     license="MIT",
     author="Department for International Trade",

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import find_packages, setup
 
 setup(
     name="directory_healthcheck",
-    version="3.1.1",
+    version="3.2.0",
     url="https://github.com/uktrade/directory-healthcheck",
     license="MIT",
     author="Department for International Trade",
@@ -16,7 +16,7 @@ setup(
     include_package_data=True,
     install_requires=[
         "django-health-check==3.17.0",
-        "django>=3.2.18,<=4.1.9",
+        "django>=4.1.10,<4.2",
     ],
     extras_require={
         "test": [
@@ -33,7 +33,7 @@ setup(
             "directory-api-client",
             "directory-forms-api-client",
             "directory-cms-client",
-            "directory-client-core>=4.3.0,<7.1.0",
+            "directory-client-core",
         ]
     },
     classifiers=[


### PR DESCRIPTION
To do (delete all that do not apply):

 - [x] Change has a jira ticket that has the correct status.
 - [x] Changelog entry added.
 - [x] (if there are vulnerable requirements) Upgraded any vulnerable dependencies.

