### PR TITLE
Upgrade to django 4.2x

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import find_packages, setup
 
 setup(
     name="directory_healthcheck",
-    version="3.1.2",
+    version="3.2",
     url="https://github.com/uktrade/directory-healthcheck",
     license="MIT",
     author="Department for International Trade",
@@ -16,7 +16,7 @@ setup(
     include_package_data=True,
     install_requires=[
         "django-health-check==3.17.0",
-        "django>=4.1.10,<4.2",
+        "django>=4.2.0,<=4.2.8",
     ],
     extras_require={
         "test": [
@@ -47,6 +47,7 @@ setup(
         "Framework :: Django :: 3.1",
         "Framework :: Django :: 3.2",
         "Framework :: Django :: 4.1",
+        "Framework :: Django :: 4.2",
         "Intended Audience :: Developers",
         "License :: OSI Approved :: MIT License",
         "Natural Language :: English",


### PR DESCRIPTION
Upgrade to django 4.2x as versions < 4.2.x become end-of-life

 - [ ] Change has a jira ticket that has the correct status.
 - [ ] (if there are vulnerable requirements) Upgraded any vulnerable dependencies.
 - [ ] (if updating requirements) Requirements have been compiled.