### PR TITLE
Update minimum django to 4.2.7

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ __pycache__/
 *.so
 
 # Distribution / packaging
+venv
 .venv
 .Python
 env/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 ## 3.4
-[Full Changelog]() (2024-01-22)
+[Full Changelog](https://github.com/uktrade/directory-healthcheck/pull/29) (2024-01-22)
 ### Enhancement
 - KLS-1864 - Upgrade Django to 4.2.7 minimum
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 3.4
+[Full Changelog]() (2024-01-22)
+### Enhancement
+- KLS-1864 - Upgrade Django to 4.2.7 minimum
+
 ## 3.1.2
 [Full Changelog](https://github.com/uktrade/directory-healthcheck/pull/26/files) (2023-07-20)
 ### Enhancement

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 3.4
+## 3.3
 [Full Changelog](https://github.com/uktrade/directory-healthcheck/pull/29) (2024-01-22)
 ### Enhancement
 - KLS-1864 - Upgrade Django to 4.2.7 minimum

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import find_packages, setup
 
 setup(
     name="directory_healthcheck",
-    version="3.2",
+    version="3.3",
     url="https://github.com/uktrade/directory-healthcheck",
     license="MIT",
     author="Department for International Trade",

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import find_packages, setup
 
 setup(
     name="directory_healthcheck",
-    version="3.4",
+    version="3.3",
     url="https://github.com/uktrade/directory-healthcheck",
     license="MIT",
     author="Department for International Trade",

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import find_packages, setup
 
 setup(
     name="directory_healthcheck",
-    version="3.3",
+    version="3.4",
     url="https://github.com/uktrade/directory-healthcheck",
     license="MIT",
     author="Department for International Trade",
@@ -16,7 +16,7 @@ setup(
     include_package_data=True,
     install_requires=[
         "django-health-check==3.17.0",
-        "django>=4.2.0,<=4.2.8",
+        "django>=4.2.7,<=4.2.8",
     ],
     extras_require={
         "test": [


### PR DESCRIPTION
Update minimum django to 4.2.7

 - [x] Change has a jira ticket that has the correct status.
 - [x] Changelog entry added.

